### PR TITLE
feat: ReDoS protection, false-positive filtering, and PII patterns

### DIFF
--- a/config/filter-patterns.yaml
+++ b/config/filter-patterns.yaml
@@ -161,6 +161,69 @@ patterns:
     severity: block
     description: Package installation commands
 
+  # === PII PATTERNS (PII-xxx) ===
+  # Detect personally identifiable information in inbound content.
+  # PII in shared repo content may indicate accidental exposure or
+  # deliberate exfiltration. These patterns are derived from Microsoft
+  # Presidio (https://github.com/microsoft/presidio) and adapted from
+  # Arbor's arbor_eval PII detection module.
+
+  - id: PII-001
+    name: credit_card_number
+    category: pii
+    pattern: '\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13}|6(?:011|5[0-9]{2})[0-9]{12})\b'
+    severity: block
+    description: Credit card numbers (Visa, Mastercard, Amex, Discover) — validate with Luhn checksum
+
+  - id: PII-002
+    name: api_key_anthropic
+    category: pii
+    pattern: 'sk-ant-[A-Za-z0-9\-_]{20,}'
+    severity: block
+    description: Anthropic API key
+
+  - id: PII-003
+    name: api_key_openai
+    category: pii
+    pattern: 'sk-(?!ant-)[a-zA-Z0-9]{32,}'
+    severity: block
+    description: OpenAI API key (excludes Anthropic keys)
+
+  - id: PII-004
+    name: api_key_github_pat
+    category: pii
+    pattern: 'gh[pousr]_[a-zA-Z0-9]{36,}'
+    severity: block
+    description: GitHub personal access token
+
+  - id: PII-005
+    name: api_key_aws
+    category: pii
+    pattern: '\b(?:AKIA|ABIA|ACCA|ASIA)[0-9A-Z]{16}\b'
+    severity: block
+    description: AWS Access Key ID
+
+  - id: PII-006
+    name: private_key_pem
+    category: pii
+    pattern: '-----BEGIN\s+(?:RSA\s+)?PRIVATE\s+KEY-----'
+    severity: block
+    description: PEM-encoded private key
+
+  - id: PII-007
+    name: email_address
+    category: pii
+    pattern: '[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}'
+    severity: review
+    description: Email address — review severity since emails appear legitimately in contributor metadata
+
+  - id: PII-008
+    name: hardcoded_user_path
+    category: pii
+    pattern: '(?:/Users/[a-zA-Z][a-zA-Z0-9_\-]+/|/home/[a-zA-Z][a-zA-Z0-9_\-]+/|C:\\Users\\[a-zA-Z][a-zA-Z0-9_\-]+\\)'
+    severity: review
+    description: Hardcoded user paths that may leak contributor identity or filesystem structure
+
 encoding_rules:
   - id: EN-001
     type: base64

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 // pai-content-filter: Inbound content security for PAI cross-project collaboration
 
 export { filterContent, filterContentString, detectFormat } from "./lib/content-filter";
-export { loadConfig, matchPatterns } from "./lib/pattern-matcher";
+export { loadConfig, matchPatterns, luhnCheck } from "./lib/pattern-matcher";
 export { detectEncoding } from "./lib/encoding-detector";
 export { validateSchema } from "./lib/schema-validator";
 export {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,7 @@ export const PatternCategory = z.enum([
   "injection",
   "exfiltration",
   "tool_invocation",
+  "pii",
 ]);
 export type PatternCategory = z.infer<typeof PatternCategory>;
 


### PR DESCRIPTION
## Summary

Adds defense-in-depth improvements to the content filter, derived from cross-project comparison with [Arbor's arbor_eval](https://github.com/trust-arbor/arbor) PII detection module (which uses patterns from [Microsoft Presidio](https://github.com/microsoft/presidio)):

- **ReDoS protection**: Lines >10KB are truncated before regex matching. Each pattern execution is time-bounded at 500ms via `safeRegexExec()` to prevent catastrophic backtracking from crafted input.
- **False-positive filtering**: Matches inside markdown code fences (`` ``` ``) and inline backtick spans are skipped via `isInsideCodeContext()`, reducing noise from code examples in documentation.
- **Luhn checksum validation**: Exported `luhnCheck()` utility (ISO/IEC 7812-1) for downstream consumers to validate credit card number matches beyond regex format matching.
- **PII pattern category**: 8 new patterns (PII-001 through PII-008):
  | ID | What | Severity |
  |---|---|---|
  | PII-001 | Credit card numbers (Visa, MC, Amex, Discover) | block |
  | PII-002 | Anthropic API keys (`sk-ant-*`) | block |
  | PII-003 | OpenAI API keys (`sk-*`, excludes Anthropic) | block |
  | PII-004 | GitHub personal access tokens (`gh[pousr]_*`) | block |
  | PII-005 | AWS Access Key IDs (`AKIA/ABIA/ACCA/ASIA*`) | block |
  | PII-006 | PEM-encoded private keys | block |
  | PII-007 | Email addresses | review |
  | PII-008 | Hardcoded user paths (macOS/Linux/Windows) | review |

## Test plan

- [x] All 303 existing + new tests pass (`bun test`)
- [x] 22 new canary tests covering all PII patterns
- [x] Luhn checksum unit tests (valid/invalid card numbers, formatting)
- [x] ReDoS protection tests (20KB lines, pathological input)
- [x] Code-context false-positive filtering tests (fence markers, inline code)
- [x] Defense-in-depth verified: long API keys caught by encoding detector (EN-001) before pattern matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)