### PR TITLE
chore(package): add main, types, and exports fields for bundler-mode consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,16 @@
   "name": "@metafactory/content-filter",
   "version": "0.1.0",
   "description": "Inbound content security — prompt injection scanning, PII detection, and sandbox enforcement",
+  "main": "src/index.ts",
   "module": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Consumers using TypeScript's bundler module resolution get \`TS2307: Cannot find module '@metafactory/content-filter'\` when trying:

\`\`\`ts
import type { FilterResult, FileFormat } from "@metafactory/content-filter";
\`\`\`

The package only declared \`module: "src/index.ts"\` — no \`main\`, \`types\`, or \`exports\`. Bundler-mode \`tsc\` needs one of those fields to locate the types entry point.

## Changes

Adds to package.json:

- **\`main\`**: \`"src/index.ts"\` (CJS-style fallback entry)
- **\`types\`**: \`"src/index.ts"\` (TS declaration entry — the source file itself is the type source since we ship untranspiled TS)
- **\`exports["."]\`**: explicit entry with \`types\`/\`import\`/\`default\` conditions for modern resolvers

## Verification

- \`bun test\`: 564/564 pass ✅
- Grove consumer (grove#176): goes from 4 content-filter-related TS errors to 0. The grove-side refactor uses:
  \`\`\`ts
  import type { FilterResult, FileFormat } from "@metafactory/content-filter";
  \`\`\`
  which previously failed to resolve.

## Context

This was authored during the #15 rename branch but didn't make it into the squash merge — posting as a standalone followup so grove#176 can go green on typecheck.

Refs: the-metafactory/grove#176

## Test plan

- [x] \`bun test\` → 564/564 pass
- [x] Grove typecheck: 4 → 0 prompt-filter errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)