### PR TITLE
docs(security): SF-004 — accurate quarantine isolation language + remove WebFetch from spec to match profile (closes #23)

### DIFF
--- a/.specify/integration-with-blackboard.md
+++ b/.specify/integration-with-blackboard.md
@@ -68,18 +68,25 @@ The security-critical moment occurs when content crosses from Level 2 (shared) t
 
 ### Layer 2: Quarantined Context Sandbox (F-004)
 
-**What it does:** Runs the content-reading agent in an isolated process with restricted capabilities. Even if injected instructions pass Layer 1, the quarantined agent cannot act on them.
+**What it does:** Runs the content-reading agent in a subprocess with a restricted MCP tool set. Tool restriction is enforced inside the subprocess's MCP runtime; the parent does not impose OS-level process isolation. Even if injected instructions pass Layer 1, the quarantined agent's effective tool surface is constrained to the profile's allowlist.
 
 **How it works:**
-- Spawns a separate `k cross-project` process (true process isolation, not just prompt instructions)
-- **Allowed tools:** Read, Glob, Grep, WebFetch (read-only operations)
-- **Denied tools:** Bash, Write, Edit, Email, Calendar, Tana, Finance, and all personal MCP tools
-- **Denied paths:** `~/.claude/skills/CORE/USER/` and all personal context
+- Spawns a separate `k cross-project` subprocess
+- The subprocess's MCP runtime enforces the tool set declared in `config/cross-project-profile.json`
+- **Allowed tools** (from profile): Read, Glob, Grep
+- **Denied tools** (from profile): Bash, Write, Edit, NotebookEdit, Task, Skill
+- **Denied paths** (from profile): `~/.claude/skills/CORE/USER/`
 - **Output:** Only TypedReferences (structured JSON with provenance metadata)
 
-**The CaMeL insight (DeepMind, 2025):** Pattern matching achieves ~99% detection, but 99% is a failing grade when agents run at scale. Architectural isolation is the primary defense — the quarantined agent literally cannot exfiltrate data because it has no tools to do so.
+**The CaMeL insight (DeepMind, 2025):** Pattern matching achieves ~99% detection, but 99% is a failing grade when agents run at scale. MCP-level tool restriction is the architectural defense in this layer — complementary to Layer 1 content filtering, not a replacement for it.
 
 **One-way data flow:** Content flows from quarantine to privileged context via TypedReferences. Never the reverse.
+
+**Limitations (honest scope):**
+- **No OS-level containment.** The subprocess is a vanilla `Bun.spawn` — no namespaces, chroot, env scrubbing, rlimits, seccomp, or `sandbox-exec`. `process.env` is inherited unscrubbed (every operator token in env flows through).
+- **Tool restriction is LLM-honored, not OS-enforced.** The defense relies on the subprocess agent reading the profile and respecting the allowed/denied lists. This is a real architectural improvement over Layer 1 alone, but it is not the same as kernel-enforced isolation.
+- **Within-allowlist exfiltration is possible.** A prompt-injected quarantined agent operating within `Read`/`Glob`/`Grep` could still encode sensitive content into paths it reads, or exfiltrate `process.env` via what it returns. Combine with Layer 1 + Layer 3 for defense-in-depth.
+- **Follow-up work:** True OS-level containment via `bwrap` (Linux) or `sandbox-exec` (macOS) plus env scrubbing is tracked as a separate enhancement.
 
 ### Layer 3: Audit Trail & Accountability (F-002)
 

--- a/.specify/specs/f-004-dual-context-sandboxing/spec.md
+++ b/.specify/specs/f-004-dual-context-sandboxing/spec.md
@@ -25,7 +25,7 @@ From F-088:
 
 Static JSON profile for the quarantined context:
 - Profile name: `cross-project`
-- Allowed tools: Read, Glob, Grep, WebFetch (read-only operations)
+- Allowed tools: Read, Glob, Grep (read-only operations — see `config/cross-project-profile.json` for the canonical list)
 - Denied tools: Bash, Write, Edit, NotebookEdit, plus all MCP server tools
 - Denied paths: `~/.claude/skills/CORE/USER/` (personal data)
 - Schema-validated via Zod

--- a/.specify/specs/f-004-dual-context-sandboxing/verify.md
+++ b/.specify/specs/f-004-dual-context-sandboxing/verify.md
@@ -22,7 +22,7 @@ bunx tsc --noEmit
 ### CrossProjectProfile (6 tests)
 - [x] Profile config file exists and parses
 - [x] Profile has correct name ("cross-project")
-- [x] Profile allows read-only tools (Read, Glob, Grep, WebFetch)
+- [x] Profile allows read-only tools (Read, Glob, Grep)
 - [x] Profile denies write/execute tools (Bash, Write, Edit, NotebookEdit)
 - [x] Profile denies USER/ path
 - [x] Rejects invalid profile


### PR DESCRIPTION
Closes #23.

## What this does

Replaces the overstated "true process isolation, not just prompt instructions" claim in F-004 documentation with accurate language describing what the quarantine runner actually provides: an MCP tool-set restriction in a subprocess, not OS-level process isolation. The implementation isn't broken — the docs claim more than it delivers.

## Changes (docs only — no code, no tests)

**`.specify/integration-with-blackboard.md`** — Layer 2 section rewrite:
- "true process isolation, not just prompt instructions" → "subprocess with a restricted MCP tool set"
- Adds explicit **Limitations (honest scope)** subsection covering:
  - No OS-level containment (no namespaces, chroot, env scrubbing, rlimits, seccomp, sandbox-exec)
  - `process.env` inherited unscrubbed
  - Tool restriction is LLM-honored, not OS-enforced
  - Within-allowlist exfiltration paths still exist
  - Follow-up: bwrap (Linux) / sandbox-exec (macOS) + env scrubbing
- Softens "literally cannot exfiltrate" claim to "effective tool surface is the profile's allowlist"

**`.specify/specs/f-004-dual-context-sandboxing/spec.md`** — line 28:
- Removes `WebFetch` from allowed-tools list to match `config/cross-project-profile.json` (which has only Read/Glob/Grep)
- Adds pointer to the profile as the canonical source

**`.specify/specs/f-004-dual-context-sandboxing/verify.md`** — line 25:
- Updates the test-checkbox text to match the profile

## What is NOT in this PR (deferred)

- **`.specify/integration-diagram.svg`** still shows `Read Glob Grep WebFetch` in two text labels. SVG visual update should be made by a maintainer with access to the diagram source — touched-by-hand SVG edits introduce rendering risk. Noted, not modified.
- **WebFetch direction question.** This PR makes the docs match the profile (removes WebFetch from docs). If WebFetch in the quarantine context is INTENDED, the correct fix is the reverse — add `"WebFetch"` to `config/cross-project-profile.json`'s `allowedTools`. Maintainer call. Happy to flip this PR if the profile is the file that should change instead.
- **True OS-level containment** via `bwrap` (Linux) or `sandbox-exec` (macOS) plus env scrubbing is a separate `feat` issue (not filed in this PR — happy to file if you want it pursued).

## No code or test impact

```
No source files touched. No test files touched. Test count and pass/fail
state unchanged from origin/main HEAD.
```

## Provenance

Found during the metafactory security exploration session on 2026-06-10 (static analysis of `src/lib/quarantine-runner.ts` against the design docs; live `k`-CLI probe deferred — `k` not installed on the dev box). Filed today per "ship what we find" doctrine — concurrent issue + PR rather than queued-behind-cadence.

Signed: `NorthwoodsSentinel <hello@northwoodssentinel.com>` (Ed25519 SSH).
