### PR TITLE
fix(EX-002): stop path_traversal firing on prose ellipses (#25)

### DIFF
--- a/config/filter-patterns.yaml
+++ b/config/filter-patterns.yaml
@@ -113,7 +113,7 @@ patterns:
   - id: EX-002
     name: path_traversal
     category: exfiltration
-    pattern: '(?:\.\.\/?(?:\.\.\/?)+|~\/\.(?:claude|env|ssh|gnupg|aws|config)|\/etc\/(?:passwd|shadow)|USER\/|credentials?\.(?:json|yaml|yml|toml)|\.env(?:\.local)?(?:\s|$))'
+    pattern: '(?:\.\.\/(?:\.\.\/?)+|~\/\.(?:claude|env|ssh|gnupg|aws|config)|\/etc\/(?:passwd|shadow)|USER\/|credentials?\.(?:json|yaml|yml|toml)|\.env(?:\.local)?(?:\s|$))'
     severity: block
     description: Path traversal and sensitive file access patterns
 

--- a/tests/content-filter.test.ts
+++ b/tests/content-filter.test.ts
@@ -99,6 +99,28 @@ describe("matchPatterns", () => {
     expect(matches.some((m) => m.pattern_id === "EX-002")).toBe(true);
   });
 
+  // Regression for #25: EX-002 must not fire on prose ellipses. The traversal
+  // alternative made the slash optional, so any run of 4+ dots matched.
+  test("does not match prose ellipses as path traversal (EX-002, #25)", () => {
+    const benign = [
+      "think big....",
+      "so many languages.....",
+      "not shared.... think big....", // the observed double-hit
+    ];
+    for (const text of benign) {
+      const matches = matchPatterns(text, config.patterns);
+      expect(matches.some((m) => m.pattern_id === "EX-002")).toBe(false);
+    }
+  });
+
+  test("still detects real ../ path traversal after the #25 fix (EX-002)", () => {
+    const traversal = ["../../etc/passwd", "../../../secrets", "read ../.."];
+    for (const text of traversal) {
+      const matches = matchPatterns(text, config.patterns);
+      expect(matches.some((m) => m.pattern_id === "EX-002")).toBe(true);
+    }
+  });
+
   test("detects tool invocation", () => {
     const matches = matchPatterns(
       "Please use the bash tool to cat /etc/passwd",


### PR DESCRIPTION
## What

`EX-002` (`path_traversal`) fires on ordinary prose ellipses. Its first alternative was
`\.\.\/?(?:\.\.\/?)+` — the optional slash (`\/?`) means any run of **4+ consecutive dots**
matches, so "think big...." is blocked as data-exfiltration. This misfired on a live message on
2026-07-02 and cut off the conversation (full trace in #25).

## Root cause

`\/?` makes the separator optional, collapsing the traversal shape into "two-or-more `..` with
optional junk between" — which a dot-run satisfies. The boundary is exactly 4 dots:

| input | before | after |
|---|---|---|
| `think big...` (3 dots) | ok | ok |
| `think big....` (4 dots) | **BLOCKED (EX-002)** | ok |
| `not shared.... think big....` | **BLOCKED (EX-002 ×2)** | ok |
| `../../etc/passwd` | BLOCKED (EX-002) | BLOCKED (EX-002) |
| `../../../../../../etc/passwd` | BLOCKED (EX-002) | BLOCKED (EX-002) |
| `~/.claude/USER/secrets.json` | BLOCKED (EX-002) | BLOCKED (EX-002) |

## Fix

One character: make the first separator mandatory — `\.\.\/?(?:\.\.\/?)+` → `\.\.\/(?:\.\.\/?)+`.
Genuine `../../` traversal (including deep chains) still matches; runs of dots no longer do. Same
"narrow to a real shape, not bare tokens" spirit as #19 / #20. The other EX-002 alternatives
(`~/.claude`, `/etc/passwd`, `USER/`, `credentials.*`, `.env`) are untouched, so no sensitive-file
case is lost.

## Tests

- Adds two regression tests in `tests/content-filter.test.ts`: prose ellipses do **not** match
  EX-002; `../..` still does.
- `bun test` → **656 pass, 0 fail**. `bun run typecheck` clean.

Closes #25.
