### PR TITLE
feat: author arc/v1 bundle manifest + validate CI (closes #28)

### DIFF
--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -1,0 +1,15 @@
+# Strict arc/v1 manifest validation — the shared CI floor for skill/bundle repos
+# (skill-estate migration WS2, the-metafactory/arc#316). The reusable workflow
+# installs a pinned arc and runs `arc validate` over this repo's
+# arc-manifest.yaml; any strict-contract violation fails the check, one line
+# each. Pinned by 40-hex commit SHA (a branch/tag ref is movable) per the
+# metafactory-actions caller-usage README. Mirrors the pathfinder template
+# (metafactory-soma-skill-handoff).
+name: validate-manifest
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  validate:
+    uses: the-metafactory/metafactory-actions/.github/workflows/validate-manifest.yml@94f76b1e191c430289ec2516746ef23623e9b7c4

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jens-Christian Fischer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,0 +1,71 @@
+# arc-manifest.yaml — capability declaration
+# metafactory-bundle-content-filter: an inbound content-security BUNDLE — a
+# prompt-injection / PII / exfiltration scanner CLI plus two Claude Code
+# PreToolUse hooks (a content-filter read-gate and a sandbox acquisition
+# enforcer). Authored fresh for arc-conformance under the skill-estate
+# migration (arc#315, issue #28, WS5 Category-A). Class = bundle (CLI + hooks +
+# library, no SKILL.md) per the recorded class decision on issue #28.
+schema: arc/v1
+name: content-filter
+namespace: "@metafactory"
+version: 0.2.0
+type: bundle
+tier: community
+description: Inbound content security — layered prompt-injection scanner (regex + heuristic), PII detection, and Claude Code sandbox enforcement.
+# LICENSE FLAG: the repo carries no LICENSE file and no package.json license
+# field (the source repo jcfischer/pai-content-filter is likewise unlicensed).
+# Applied the spec DD-13 default (Apache-2.0, "unless already chosen"). This is
+# NOT a confirmed choice — jcfischer (author) / principal must confirm and add a
+# LICENSE file before merge.
+license: Apache-2.0
+
+# Attribution principle: this bundle was authored by Jens-Christian Fischer and
+# transferred into the org 2026-04-07 (from jcfischer/pai-content-filter). It is
+# not our code, so the canonical author is preserved as jcfischer.
+author:
+  name: Jens-Christian Fischer
+  github: jcfischer
+
+provides:
+  cli:
+    - name: content-filter
+      command: bun src/cli.ts
+      description: "Scan a file for prompt-injection / PII / exfiltration patterns; inspect the audit trail and loaded config."
+  hooks:
+    # Read-gate: any file under the sandbox dir must pass the filter before an
+    # agent may Read/Glob/Grep it. Fail-closed (exit 2 on malicious/erroring).
+    - event: PreToolUse
+      matcher: "Read|Glob|Grep"
+      command: hooks/ContentFilter.hook.ts
+    # Acquisition enforcer: gates Bash tool calls (git clone / curl -o / wget)
+    # so external content lands only inside the sandbox dir. Fail-closed.
+    - event: PreToolUse
+      matcher: "Bash"
+      command: hooks/SandboxEnforcer.hook.ts
+
+# Honest capability surface (arc/v1 requires this block).
+capabilities:
+  filesystem:
+    read:
+      # The scanner reads the file under inspection (the path passed to `check`
+      # or intercepted by the PreToolUse read-gate) plus its pattern config.
+      - ~/.config/content-filter/
+    write:
+      # Append-only, monthly-partitioned JSONL audit trail (src/lib/audit.ts:
+      # mkdirSync + appendFileSync under the log dir).
+      - ~/.config/content-filter/audit/
+  network: []
+  bash:
+    # The bundle EXECUTES no shell. SandboxEnforcer is a PreToolUse hook that
+    # INSPECTS Bash tool calls and blocks out-of-sandbox acquisition — it never
+    # runs a command itself, and the CLI/lib never shell out. So no bash-exec
+    # capability is claimed (this is the honest surface, not a false empty).
+    allowed: false
+  secrets: []
+
+depends_on:
+  tools:
+    - name: bun
+
+bundle:
+  exclude: [vendor, MEMORY, node_modules, .git, .specify, tests]

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,23 +1,27 @@
 # arc-manifest.yaml — capability declaration
-# metafactory-bundle-content-filter: an inbound content-security BUNDLE — a
+# metafactory-bundle-content-filter: an inbound content-security bundle — a
 # prompt-injection / PII / exfiltration scanner CLI plus two Claude Code
 # PreToolUse hooks (a content-filter read-gate and a sandbox acquisition
 # enforcer). Authored fresh for arc-conformance under the skill-estate
-# migration (arc#315, issue #28, WS5 Category-A). Class = bundle (CLI + hooks +
-# library, no SKILL.md) per the recorded class decision on issue #28.
+# migration (arc#315, issue #28, WS5 Category-A).
+#
+# Repo-name class = bundle (CLI + hooks + library, no SKILL.md — class decision
+# on issue #28). The manifest `type`, a separate axis, is `tool`: arc's
+# installer has no `bundle` case (it throws "Unsupported artifact type"), so
+# bundle-NAMED repos declare an installable type — exactly as the reference
+# bundle metafactory-bundle-discord uses `type: skill`. The validator↔installer
+# `bundle` mismatch is tracked as its own arc issue.
 schema: arc/v1
 name: content-filter
 namespace: "@metafactory"
 version: 0.2.0
-type: bundle
+type: tool
 tier: community
 description: Inbound content security — layered prompt-injection scanner (regex + heuristic), PII detection, and Claude Code sandbox enforcement.
-# LICENSE FLAG: the repo carries no LICENSE file and no package.json license
-# field (the source repo jcfischer/pai-content-filter is likewise unlicensed).
-# Applied the spec DD-13 default (Apache-2.0, "unless already chosen"). This is
-# NOT a confirmed choice — jcfischer (author) / principal must confirm and add a
-# LICENSE file before merge.
-license: Apache-2.0
+# License: MIT, set by principal decision 2026-07-17 (matches jcfischer's other
+# metafactory repos), pending jcfischer's ack. Manifest and the repo LICENSE
+# file agree.
+license: MIT
 
 # Attribution principle: this bundle was authored by Jens-Christian Fischer and
 # transferred into the org 2026-04-07 (from jcfischer/pai-content-filter). It is


### PR DESCRIPTION
WS5 Category-A arc-conformance for content-filter. Closes #28. Repo renamed `content-filter` → `metafactory-bundle-content-filter` (2026-07-17, by the epic lead).

## Class decision: BUNDLE repo-name, `type: tool` manifest (recorded on #28)
Lead artifacts are a CLI (`src/cli.ts`) + two Claude Code PreToolUse hooks + a published library (`@metafactory/content-filter`), with **no SKILL.md**. Per the class-choice rule the repo NAME is `metafactory-bundle-content-filter`. The manifest **`type` is `tool`** (a separate axis): arc 0.40.2's installer has no `bundle` case (it throws `Unsupported artifact type "bundle"`), so bundle-named repos declare an installable type — as the reference bundle `metafactory-bundle-discord` uses `type: skill`. The validator↔installer `bundle` mismatch is tracked as its own arc issue. Evidence: https://github.com/the-metafactory/content-filter/issues/28#issuecomment-4993376302

## Fresh manifest (there was none to normalize)
- `schema: arc/v1`, `name: content-filter`, `type: tool`, `tier: community`.
- **Author = `{ Jens-Christian Fischer, jcfischer }`** (attribution principle — jcfischer authored it, 27/33 commits, transferred from `jcfischer/pai-content-filter` 2026-04-07; not rewritten to us).
- `provides.cli` (`bun src/cli.ts`) + `provides.hooks` (both PreToolUse, matched `Read|Glob|Grep` and `Bash`).
- **Honest capabilities:** fs read of scanned content + config (`~/.config/content-filter/`); append-only audit write (`~/.config/content-filter/audit/`); `network: []`; `bash: { allowed: false }` — the SandboxEnforcer *inspects* Bash tool calls, never executes a shell.

## License
`license: MIT`, set by **principal decision 2026-07-17** (matches jcfischer's other metafactory repos), pending @jcfischer's ack — flagged so the record is visible to him. Matching `LICENSE` file (MIT, © 2026 Jens-Christian Fischer) included so file and manifest agree. (The repo previously had no LICENSE file / no package.json license field.)

## CI + install proof
SHA-pinned `validate-manifest` caller. `arc validate` exit 0. Install round-trip (clean XDG-isolated env, arc 0.40.2): `✅ Installed content-filter v0.2.0`; CLI shim placed; **both hooks registered** in `~/.claude/settings.json` PreToolUse; `arc verify` green except one spurious `skill symlink` ❌ (verify checks a skill link even for `type: tool` — cosmetic).

## Consumer sweep + compass
Posted on #28; compass rekey + Migrations "Done" row in the-metafactory/compass#134. Live npm deps in grove/grove-v2/cortex/pilot resolve via redirect (cortex/pilot SHA-pinned) — batched dependency-URL bump is close-out follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
